### PR TITLE
fix: remove warning when adding OS version card to dashboard

### DIFF
--- a/frontend/src/components/modals/EditCardsModal.jsx
+++ b/frontend/src/components/modals/EditCardsModal.jsx
@@ -77,7 +77,6 @@ function EditCardsModal({
               platform: addCardPlatform,
             },
           ]);
-          setCardDataSelect(`${title} has been added.`);
         }
       }
 
@@ -147,10 +146,6 @@ function EditCardsModal({
     visible,
     addCardPlatform,
     addCardType,
-    cards,
-    iPadData,
-    iPhoneData,
-    macData,
   ]);
 
   function cardType(type) {


### PR DESCRIPTION
When adding a compliance card to the dashboard for OS Version, there was a bug where it display a message "Card already exists".  This is because the card gets added to the array and then the React hook useEffect is called and in that function, it searches for an existing card.  Bug was fixed by removing the cards array from the useEffect dependency array.