### PR TITLE
GraphQL optimization for improved app version search

### DIFF
--- a/deployment/app.yaml
+++ b/deployment/app.yaml
@@ -1,0 +1,11 @@
+runtime: nodejs18
+handlers:
+  # Serve all static files with url ending with a file extension
+  - url: /(.*\..+)$
+    static_files: build/\1
+    secure: always
+    upload: build/(.*\..+)$
+  # Catch all handler to index.html
+  - url: /.*
+    static_files: build/index.html
+    upload: build/index.html


### PR DESCRIPTION
Searching for installed application versions from the dashboard is currently not efficient and the result is the app cannot scale for large deployments (> 2,000 devices).  This is the first step in creating an optimized GraphQL schema to fix this problem.